### PR TITLE
Add working CD pipeline

### DIFF
--- a/.github/workflows/env.yaml
+++ b/.github/workflows/env.yaml
@@ -1,3 +1,3 @@
-DATASET_ID: demo-pipeline
+dtset_id: demo-pipeline
 table_name: bitcoin_price
 url: http://api.coindesk.com/v1/bpi/currentprice/THB.json

--- a/.github/workflows/env.yaml
+++ b/.github/workflows/env.yaml
@@ -1,0 +1,3 @@
+dataset_id: demo-pipeline
+table_name: bitcoin_price
+url: http://api.coindesk.com/v1/bpi/currentprice/THB.json

--- a/.github/workflows/env.yaml
+++ b/.github/workflows/env.yaml
@@ -1,3 +1,3 @@
-dataset_id: demo-pipeline
+DATASET_ID: demo-pipeline
 table_name: bitcoin_price
 url: http://api.coindesk.com/v1/bpi/currentprice/THB.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Test
+        run: echo ${{ secrets.SECRET_TOKEN }}
+        
       - name: Setup GCloud
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           # Optional service account key to use for authentication to GCP. This should be the JSON
           # formatted private key which can be exported from the Cloud Console. The
           # value can be raw or base64-encoded.
-          credentials: {{ secrets.gcp_credentials }}
+          credentials: ${{ secrets.gcp_credentials }}
           # Name of the Cloud Function.
           name: hello world
           # Description for the Cloud Function.
@@ -56,4 +56,3 @@ jobs:
           entry_point: insert_data
           # Runtime to use for the function.
           runtime: python38
-      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           # Description for the Cloud Function.
           description: test-description
           # Project to deploy the function in.
-          project_id: root-sanctuary-276107
+          project_id: ${{ secrets.GCP_PROJ_NAME }}
           # Region to deploy the function in. Defaults to us-central1, if not specified.
           region: us-central1
           # Name of a function (as defined in source code) that will be executed. Defaults to the resource name suffix, if not specified. 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,4 +59,4 @@ jobs:
           entry_point: insert_data
           # Runtime to use for the function.
           runtime: python38
-          env_vars_file: env.yaml
+          env_vars_file: .github/workflows/env.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,9 @@ jobs:
           # value can be raw or base64-encoded.
           credentials: ${{ secrets.GCP_CREDENTIALS }}
           # Name of the Cloud Function.
-          name: hello world
+          name: hello-world
           # Description for the Cloud Function.
-          description: test description
+          description: test-description
           # Project to deploy the function in.
           project_id: root-sanctuary-276107
           # Region to deploy the function in. Defaults to us-central1, if not specified.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    
+    # Environment
+    environment: test-deployment
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Setup GCloud
         uses: google-github-actions/setup-gcloud@master
         with:
+          project_id: ${{ secrets.GCP_PROJ_NAME }}
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}
           export_default_credentials: true
     
@@ -53,8 +54,6 @@ jobs:
           name: hello-world
           # Description for the Cloud Function.
           description: test-description
-          # Project to deploy the function in.
-          project_id: ${{ secrets.GCP_PROJ_NAME }}
           # Region to deploy the function in. Defaults to us-central1, if not specified.
           region: us-central1
           # Name of a function (as defined in source code) that will be executed. Defaults to the resource name suffix, if not specified. 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Setup GCloud
         uses: google-github-actions/setup-gcloud@master
         with:
+          service_account_email:  github-actions-deploy-cloud-fu@root-sanctuary-276107.iam.gserviceaccount.com
           project_id: ${{ secrets.GCP_PROJ_NAME }}
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}
           export_default_credentials: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Setup GCloud
         uses: google-github-actions/setup-gcloud@master
         with:
-          service_account_key: 1234
-          # ${{ secrets.GCP_CREDENTIALS }}
+          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
           export_default_credentials: true
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Test
-        run: echo ${{ secrets.SECRET_TOKEN }}
-        
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          project_id: ${{ secrets.GCP_PROJ_NAME }}
-          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-          export_default_credentials: true
-    
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
@@ -47,6 +37,13 @@ jobs:
         run: |
           echo Add other actions to build,
           echo test, and deploy your project.
+          
+      - name: Setup GCloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJ_NAME }}
+          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
+          export_default_credentials: true
       
       - name: Cloud Functions Deploy
         uses: google-github-actions/deploy-cloud-functions@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           # Optional service account key to use for authentication to GCP. This should be the JSON
           # formatted private key which can be exported from the Cloud Console. The
           # value can be raw or base64-encoded.
-          credentials: ${{ secrets.gcp_credentials }}
+          credentials: ${{ secrets.GCP_CREDENTIALS }}
           # Name of the Cloud Function.
           name: hello world
           # Description for the Cloud Function.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,9 +49,7 @@ jobs:
           echo test, and deploy your project.
       
       - name: Cloud Functions Deploy
-        # You may pin to the exact commit or the version.
-        # uses: google-github-actions/deploy-cloud-functions@7faa962492ec7b650406d15004fc19c6880f94d0
-        uses: google-github-actions/deploy-cloud-functions@v0.1.2
+        uses: google-github-actions/deploy-cloud-functions@main
         with:
           # Name of the Cloud Function.
           name: hello-world

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,3 +59,4 @@ jobs:
           entry_point: insert_data
           # Runtime to use for the function.
           runtime: python38
+          env_vars_file: env.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         uses: google-github-actions/deploy-cloud-functions@main
         with:
           # Name of the Cloud Function.
-          name: hello-world
+          name: insert_data
           # Description for the Cloud Function.
           description: test-description
           # Region to deploy the function in. Defaults to us-central1, if not specified.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,6 @@ jobs:
         # uses: google-github-actions/deploy-cloud-functions@7faa962492ec7b650406d15004fc19c6880f94d0
         uses: google-github-actions/deploy-cloud-functions@v0.1.2
         with:
-          # Optional service account key to use for authentication to GCP. This should be the JSON
-          # formatted private key which can be exported from the Cloud Console. The
-          # value can be raw or base64-encoded.
-          credentials: ${{ secrets.GCP_CREDENTIALS }}
           # Name of the Cloud Function.
           name: hello-world
           # Description for the Cloud Function.
@@ -56,3 +52,7 @@ jobs:
           entry_point: insert_data
           # Runtime to use for the function.
           runtime: python38
+          # Optional service account key to use for authentication to GCP. This should be the JSON
+          # formatted private key which can be exported from the Cloud Console. The
+          # value can be raw or base64-encoded.
+          credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,12 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Setup GCloud
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
+          export_default_credentials: true
+    
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
@@ -52,7 +58,3 @@ jobs:
           entry_point: insert_data
           # Runtime to use for the function.
           runtime: python38
-          # Optional service account key to use for authentication to GCP. This should be the JSON
-          # formatted private key which can be exported from the Cloud Console. The
-          # value can be raw or base64-encoded.
-          credentials: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Setup GCloud
         uses: google-github-actions/setup-gcloud@master
         with:
-          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
+          service_account_key: 1234
+          # ${{ secrets.GCP_CREDENTIALS }}
           export_default_credentials: true
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Working CD pipeline for GCP cloud function

Instructions:
1. In GCP IAM, Create new service account with `Cloud Functions Admin` permission
2. Generate new key. Download secret key as JSON.
3. In GCP IAM, add <SA-name>@<project-id>.iam.gserviceaccount.com with role `Service Account User` as a member on the root service account <Project_name>@appspot.gserviceaccount.com
4. In GitHub Repo Settings, add new environment named `test-deployment` (or update `test-deployment` in .github/workflows/main.yml to the new environment name)
5. Create new secret GCP_PROJ_NAME with value = project ID e.g. root-sanctuary-01234
6. Create new secret GCP_CREDENTIALS with value = base64-encoded JSON value from the content of the file in 2.
7. Test run this workflow. It should create new Cloud Function in the project.
8. (Optional) Change the permission for this Cloud Function to `allUsers` for public access if required